### PR TITLE
Improve light theme contrast and flash messages

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,8 +1,11 @@
 body {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    min-height: 100vh;
     transition: background-color 0.3s ease, color 0.3s ease;
+    font-family: "Raleway", "Segoe UI", Tahoma, Geneva, sans-serif;
+    line-height: 1.6;
+    letter-spacing: 0.01em;
 }
 
 .ubuntu-mono-regular {
@@ -55,7 +58,7 @@ body[data-theme="dark"] {
 
 body[data-theme="light"] {
     background-color: #f8fafc;
-    color: #0f172a;
+    color: #0b1120;
     color-scheme: light;
 }
 
@@ -75,11 +78,11 @@ body[data-theme="light"] .text-gray-400,
 body[data-theme="light"] .text-gray-500,
 body[data-theme="light"] .text-gray-100:not(.bg-green-500):not(.bg-indigo-500):not(.bg-blue-600),
 body[data-theme="light"] .text-white:not(.bg-green-500):not(.bg-indigo-500):not(.bg-blue-600) {
-    color: #1f2937 !important;
+    color: #111827 !important;
 }
 
 body[data-theme="light"] .text-gray-300 {
-    color: #334155 !important;
+    color: #1f2937 !important;
 }
 
 body[data-theme="light"] a,
@@ -101,20 +104,20 @@ body[data-theme="light"] .bg-gray-800 {
 }
 
 body[data-theme="light"] .bg-gray-700 {
-    background-color: #cbd5f5 !important;
-    color: #0f172a !important;
+    background-color: #e2e8f0 !important;
+    color: #0b1120 !important;
 }
 
 body[data-theme="light"] .bg-gray-600 {
-    background-color: #bcd0f7 !important;
-    color: #0f172a !important;
+    background-color: #e0e7ff !important;
+    color: #0b1120 !important;
 }
 
 body[data-theme="light"] .hover\:bg-gray-700:hover,
 body[data-theme="light"] .hover\:bg-gray-800:hover,
 body[data-theme="light"] .hover\:bg-gray-900:hover {
-    background-color: #d1ddfb !important;
-    color: #0f172a !important;
+    background-color: #dbeafe !important;
+    color: #0b1120 !important;
 }
 
 body[data-theme="light"] .border-gray-800,
@@ -152,6 +155,38 @@ body[data-theme="light"] pre {
     background-color: #f1f5f9 !important;
     color: #0f172a;
     border: 1px solid #cbd5e1;
+}
+
+.flash-message {
+    background-color: rgba(30, 41, 59, 0.92);
+    border: 1px solid #334155;
+    border-radius: 0.75rem;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
+    color: #f8fafc;
+    padding: 1.25rem 1.5rem;
+    transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.flash-message__text {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.015em;
+}
+
+.flash-message__text + .flash-message__text {
+    margin-top: 0.5rem;
+}
+
+body[data-theme="light"] .flash-message {
+    background-color: #f0f9ff;
+    border-color: #38bdf8;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    color: #0b1120;
+}
+
+body[data-theme="light"] .flash-message__text {
+    color: inherit;
 }
 
 body[data-theme="light"] table,

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -94,13 +94,17 @@
               {% endif %}
             </div>
         </header>
-        {% if get_flashed_messages() %}
-          <div class="container mx-auto">
-              <div class="flex flex-col text-center w-full">
-                  <p class="mx-auto leading-relaxed text-base text-white">{{ get_flashed_messages() | join(" ") }}</p>
+        {% with messages = get_flashed_messages() %}
+          {% if messages %}
+            <div class="container mx-auto px-4">
+              <div class="flash-message" role="status" aria-live="polite">
+                {% for message in messages %}
+                  <p class="flash-message__text">{{ message }}</p>
+                {% endfor %}
               </div>
-          </div>
-        {% endif %}
+            </div>
+          {% endif %}
+        {% endwith %}
 
         {% block body %}
         


### PR DESCRIPTION
## Summary
- tune the light theme palette and typography to provide better foreground/background contrast
- restyle flash message containers for improved readability in light mode and add semantic markup

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1436bc58483258d6d87db051cc8bb